### PR TITLE
Add R36S platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ ifeq ($(PLATFORM),rgb30)
 CFLAGS += -DBR2 -DRGB30
 else ifeq ($(PLATFORM),h700)
 CFLAGS += -DBR2 -DH700
+else ifeq ($(PLATFORM),r36s)
+CFLAGS += -DBR2 -DR36S
 else ifeq ($(PLATFORM),pi)
 CFLAGS += -DBR2 -DRPI
 endif

--- a/README.md
+++ b/README.md
@@ -7,16 +7,7 @@ Simple Terminal Emulator for embedded Linux handhelds, migrated from SDL1.2 to S
 <img src="images/st-img3.jpeg?raw=true" alt="Image3" width="250"/>
 <img src="images/st-img1-trimuisp.jpg?raw=true" alt="Image1-TrimuiSP" width="250"/>
 
-# Build
-
-For generic linux:
-
-```bash
-sudo apt install build-essential libsdl2-dev libsdl2-ttf-dev
-make
-```
-
-# Run
+## Run
 
 ```bash
 ./simple-terminal
@@ -51,9 +42,40 @@ Simple Terminal supports scrollback history to review previous output:
 - **Scroll indicator**: When scrolled, a `[offset]^` indicator appears in the top-right corner
 - **Auto-reset**: Any key press (except scroll keys) returns to the bottom of the buffer
 
-# Build with buildroot toolchain
 
-you can build everything for the target device with buildroot:  
+## Platforms
+
+SimpleTerminal includes built-in input mappings for several embedded handheld devices.
+
+When building for a handheld device, specify the target platform using the PLATFORM variable:
+
+```bash
+make PLATFORM=<platform>
+```
+
+Currently supported platforms include:
+  - `rgb30`
+  - `h700`
+  - `r36s`
+  - `pi` (Raspberry Pi / generic controller)
+
+If no platform is specified, SimpleTerminal builds with a generic Linux keyboard mapping.
+
+Note: The `PLATFORM` option currently only affects controller and keyboard input mappings. Other devices may work correctly if their controller layout matches one of the existing platforms.
+
+
+## Build
+
+### Generic linux
+
+```bash
+sudo apt install build-essential libsdl2-dev libsdl2-ttf-dev
+make
+```
+
+### Build with buildroot toolchain
+
+You can build everything for the target device with buildroot:
 https://github.com/haoict/TiniLinux/blob/master/README.md#build
 
 or build the toolchain only and build simple-terminal separately
@@ -71,7 +93,34 @@ export CROSS_COMPILE=/home/haoict/TiniLinux/output.toolchain_x86_64_aarch64/host
 make
 ```
 
-# To edit embedded bitmap font
+### Build using Podman
+
+You can also build SimpleTerminal using Podman.
+
+```bash
+podman run --rm -it \
+  -v "$PWD:/work:Z" -w /work \
+  docker.io/debian:trixie-slim \
+  bash -lc '
+    set -euo pipefail
+
+    dpkg --add-architecture arm64
+    apt update
+    apt install -y --no-install-recommends \
+      make pkg-config \
+      gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+      libsdl2-dev:arm64 libsdl2-ttf-dev:arm64
+
+    export CC=aarch64-linux-gnu-gcc
+    export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+    export PKG_CONFIG_SYSROOT_DIR=/
+
+    make clean || true
+    make PLATFORM=r36s CC="$CC"
+  '
+```
+
+## To edit embedded bitmap font
 
 https://simple-terminal-psi.vercel.app
 

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -6,23 +6,47 @@
 #define KMOD_SYNTHETIC (1 << 14)
 
 #if defined(BR2) && !defined(RPI)  // Buildroot handhelds with SDL2 (not raspberry pi)
+
+// Physical button layout
+
+#if defined(R36S)
+// R36S / dArkOS (GO-Super Gamepad) confirmed via jstest/evtest:
+// D-pad: 8=Up, 9=Down, 10=Left, 11=Right
+// Select=12, Start=13, L3=14, R3=15, FN(MENU)=16
+#define JOYBUTTON_UP -8
+#define JOYBUTTON_DOWN -9
+#define JOYBUTTON_LEFT -10
+#define JOYBUTTON_RIGHT -11
+#define JOYBUTTON_SELECT -12
+#define JOYBUTTON_START -13
+#define JOYBUTTON_L3 -14
+#define JOYBUTTON_R3 -15
+#define JOYBUTTON_MENU -16
+
+#else
+// Default BR2 handheld layout (rgb30, h700, etc.)
 #define JOYBUTTON_UP -13
 #define JOYBUTTON_DOWN -14
 #define JOYBUTTON_LEFT -15
 #define JOYBUTTON_RIGHT -16
+#define JOYBUTTON_SELECT -8
+#define JOYBUTTON_START -9
+#define JOYBUTTON_L3 -11
+#define JOYBUTTON_R3 -12
+#define JOYBUTTON_MENU -10
+#endif
+
+// Shared buttons
 #define JOYBUTTON_A -1
 #define JOYBUTTON_B -0
 #define JOYBUTTON_X -2
 #define JOYBUTTON_Y -3
-#define JOYBUTTON_SELECT -8
-#define JOYBUTTON_START -9
 #define JOYBUTTON_L1 -4
 #define JOYBUTTON_R1 -5
 #define JOYBUTTON_L2 -6
 #define JOYBUTTON_R2 -7
-#define JOYBUTTON_L3 -11
-#define JOYBUTTON_R3 -12
-#define JOYBUTTON_MENU -10
+
+// Logical key bindings
 
 #define KEY_UP JOYBUTTON_UP
 #define KEY_DOWN JOYBUTTON_DOWN


### PR DESCRIPTION
This PR adds proper controller button mapping for the R36S handheld.

Previously, SimpleTerminal would instantly quit on R36S due to mismatched button IDs. This PR adds a dedicated mapping so the terminal works as expected on that device.

Tested on
- R36S running dArkOS (RG351MP image + R36S dtb)
- Verified button mapping using jstest and evtest
- Confirmed keyboard and terminal input work correctly

In addition, this PR updates the README to document available PLATFORM options and slightly improves the build instructions.