### PR TITLE
Add a buttonmap for the RG35XXSP.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ ifeq ($(PLATFORM),rgb30)
 CFLAGS += -DBR2 -DRGB30
 else ifeq ($(PLATFORM),h700)
 CFLAGS += -DBR2 -DH700
+else ifeq ($(PLATFORM),rg35xxsp)
+CFLAGS += -DBR2 -DRG35XXSP
 else ifeq ($(PLATFORM),r36s)
 CFLAGS += -DBR2 -DR36S
 else ifeq ($(PLATFORM),pi)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Currently supported platforms include:
   - `rgb30`
   - `h700`
   - `r36s`
+  - `rg35xxsp`
   - `pi` (Raspberry Pi / generic controller)
 
 If no platform is specified, SimpleTerminal builds with a generic Linux keyboard mapping.

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -13,6 +13,14 @@
 // R36S / dArkOS (GO-Super Gamepad) confirmed via jstest/evtest:
 // D-pad: 8=Up, 9=Down, 10=Left, 11=Right
 // Select=12, Start=13, L3=14, R3=15, FN(MENU)=16
+#define JOYBUTTON_A -1
+#define JOYBUTTON_B -0
+#define JOYBUTTON_X -2
+#define JOYBUTTON_Y -3
+#define JOYBUTTON_L1 -4
+#define JOYBUTTON_R1 -5
+#define JOYBUTTON_L2 -6
+#define JOYBUTTON_R2 -7
 #define JOYBUTTON_UP -8
 #define JOYBUTTON_DOWN -9
 #define JOYBUTTON_LEFT -10
@@ -23,8 +31,41 @@
 #define JOYBUTTON_R3 -15
 #define JOYBUTTON_MENU -16
 
+#elif defined(RG35XXSP)
+#define JOYBUTTON_A -3
+#define JOYBUTTON_B -4
+#define JOYBUTTON_X -6
+#define JOYBUTTON_Y -5
+#define JOYBUTTON_L1 -7
+#define JOYBUTTON_R1 -8
+#define JOYBUTTON_L2 -12
+#define JOYBUTTON_R2 -13
+
+// D-pad keys are treated as joystick hats on the 35xxSP, so here we map to
+// synthetic keys that are emitted from the hat event handling code.
+#define JOYBUTTON_UP -100
+#define JOYBUTTON_DOWN -101
+#define JOYBUTTON_LEFT -102
+#define JOYBUTTON_RIGHT -103
+
+#define JOYBUTTON_SELECT -9
+#define JOYBUTTON_START -10
+// Volume up.
+#define JOYBUTTON_L3 -2
+// Volume down.
+#define JOYBUTTON_R3 -1
+#define JOYBUTTON_MENU -11
+
 #else
 // Default BR2 handheld layout (rgb30, h700, etc.)
+#define JOYBUTTON_A -1
+#define JOYBUTTON_B -0
+#define JOYBUTTON_X -2
+#define JOYBUTTON_Y -3
+#define JOYBUTTON_L1 -4
+#define JOYBUTTON_R1 -5
+#define JOYBUTTON_L2 -6
+#define JOYBUTTON_R2 -7
 #define JOYBUTTON_UP -13
 #define JOYBUTTON_DOWN -14
 #define JOYBUTTON_LEFT -15
@@ -35,16 +76,6 @@
 #define JOYBUTTON_R3 -12
 #define JOYBUTTON_MENU -10
 #endif
-
-// Shared buttons
-#define JOYBUTTON_A -1
-#define JOYBUTTON_B -0
-#define JOYBUTTON_X -2
-#define JOYBUTTON_Y -3
-#define JOYBUTTON_L1 -4
-#define JOYBUTTON_R1 -5
-#define JOYBUTTON_L2 -6
-#define JOYBUTTON_R2 -7
 
 // Logical key bindings
 

--- a/src/main.c
+++ b/src/main.c
@@ -975,6 +975,9 @@ void main_loop(void) {
     int running = 1;
     int button_up_held = 0, button_down_held = 0, button_left_held = 0, button_right_held = 0;
     Uint32 last_button_held_time = 0;
+#if defined(RG35XXSP)
+    Uint8 joy0_hat0_last_state = 0;
+#endif
     while (running) {
         while (SDL_PollEvent(&ev))
         // while (SDL_WaitEvent(&ev))
@@ -1022,6 +1025,42 @@ void main_loop(void) {
                                                }}};
 
                 SDL_PushEvent(&sdl_event);
+#if defined(RG35XXSP)
+            } else if (ev.type == SDL_JOYHATMOTION && ev.jhat.which == 0 &&
+                       ev.jhat.hat == 0) {
+                // The RG35XXSP does not treat the d-pad directions as individual buttons; instead it treats it as a joystick hat.
+                // Here we translate hat events into key events to handle those directions.
+                static const Uint8 HAT_MASKS[] = {
+                  SDL_HAT_LEFT, SDL_HAT_RIGHT, SDL_HAT_UP, SDL_HAT_DOWN,
+                };
+                static const int HAT_BUTTONS[] = {
+                  JOYBUTTON_LEFT, JOYBUTTON_RIGHT, JOYBUTTON_UP, JOYBUTTON_DOWN,
+                };
+                for (int i = 0; i < 4; i++) {
+                    if ((joy0_hat0_last_state & HAT_MASKS[i]) && !(ev.jhat.value & HAT_MASKS[i])) {
+                        SDL_Event sdl_event = {.key = {.type = SDL_KEYUP,
+                                                       .state = SDL_RELEASED,
+                                                       .keysym = {
+                                                           .scancode = HAT_BUTTONS[i],
+                                                           .sym = HAT_BUTTONS[i],
+                                                           .mod = 0,
+                                                       }}};
+
+                        SDL_PushEvent(&sdl_event);
+                    } else if (!(joy0_hat0_last_state & HAT_MASKS[i]) && (ev.jhat.value & HAT_MASKS[i])) {
+                        SDL_Event sdl_event = {.key = {.type = SDL_KEYDOWN,
+                                                       .state = SDL_PRESSED,
+                                                       .keysym = {
+                                                           .scancode = HAT_BUTTONS[i],
+                                                           .sym = HAT_BUTTONS[i],
+                                                           .mod = 0,
+                                                       }}};
+
+                        SDL_PushEvent(&sdl_event);
+                    }
+                }
+                joy0_hat0_last_state = ev.jhat.value;
+#endif
             } else {
                 if (event_handler[ev.type]) (event_handler[ev.type])(&ev);
             }


### PR DESCRIPTION
Hello haoict!

This change adds a buttonmap for the RG35XXSP. It seems like the SP (at least on my Knulli install) exposes the d-pad as a joystick hat rather than buttons like the other BR2 devices. I've added some handling for this case to synthesize the button events that SimpleTerminal expects. It currently just assumes Joystick 0 and Hat 0, though this could be made more robust if needed.

I'm unsure if the hat d-pad is a Knulli-specific thing. Feel free to ignore this pull-request if it's not relevant to your platform!

Cheers,
Josh